### PR TITLE
[Fix] Handle Duplicate Rules in Parser

### DIFF
--- a/iptables/parser.go
+++ b/iptables/parser.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -113,6 +114,17 @@ func (p *parser) handleRule(line string) {
 		Rule:    strings.Join(subParser.flags, " "),
 	}
 	chain := p.currentTable[subParser.chain]
+
+	// Filtering mechanism to prevent multiple duplicate rules to get created.
+	// We simply skip addition of the rule if it already exists in the chain.
+	// Note: We considering ONLY rule to uniquely identify it, and NOT packets and bytes.
+	doesRuleExistInChain := func(rule Rule) bool {
+		return rule.Rule == r.Rule
+	}
+	if slices.ContainsFunc(chain.Rules, doesRuleExistInChain) {
+		return
+	}
+
 	chain.Rules = append(chain.Rules, r)
 	p.currentTable[subParser.chain] = chain
 }

--- a/iptables_exporter.go
+++ b/iptables_exporter.go
@@ -115,16 +115,7 @@ func (c *collector) Collect(metricChan chan<- prometheus.Metric) {
 				chainName,
 				chain.Policy,
 			)
-			// Hash map to ensure only unique rule, per table, per chain is used to create metric.
-			// If we encounter multiple duplicate rules, we simply going to skip the iteration for that rule.
-			// Note: We considering rule, packets, and bytes altogether to uniquely identify a rule.
-			reportedRule := make(map[iptables.Rule]struct{}, len(chain.Rules))
 			for _, rule := range chain.Rules {
-				if _, exists := reportedRule[rule]; exists {
-					continue
-				}
-				reportedRule[rule] = struct{}{}
-
 				metricChan <- prometheus.MustNewConstMetric(
 					rulePacketsDesc,
 					prometheus.CounterValue,


### PR DESCRIPTION
There was an edge case which we didn't considered in https://github.com/Obmondo/iptables_exporter/pull/3.
If there are duplicate rules in a chain with different `Packets` and `Bytes`, we need to skip them, which we were not doing.

This PR will fix that edge case by making changes directly in the parser. This will help to keep the outside code consistent, and make testing easy.

Fixes: https://gitea.obmondo.com/EnableIT/7ejidqmfi9/issues/1308
Signed-off-by: VILJkid <sidvjmostwanted@gmail.com>